### PR TITLE
Add search and reset functionality

### DIFF
--- a/src/api-calls.js
+++ b/src/api-calls.js
@@ -3,4 +3,9 @@ function getNews() {
   .then(res => res.json());
 };
 
-export { getNews };
+function searchNews(search) {
+  return fetch(`https://newsapi.org/v2/everything?q=${search}&apiKey=29b06f4826d24d779a8d498bac5548aa`)
+  .then(res => res.json());
+};
+
+export { getNews, searchNews };

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -7,19 +7,34 @@ import Search from '../Search/Search';
 import Articles from '../Articles/Articles';
 import ArticleInfo from '../ArticleInfo/ArticleInfo';
 
-import { getNews } from '../../api-calls';
+import { getNews, searchNews } from '../../api-calls';
 import mockData from '../../mock-data';
 
 const App = () => {
   const [news, setNews] = useState([]);
+  const [search, setSearch] = useState([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [searched, setSearched] = useState(false);
   const [error, setError] = useState('');
 
   useEffect(() => {
-    
     setNews(mockData.map((article, index) => ({...article, id: index})));
     // getNews()
-    // .then(data => data.status === 'ok' ? setNews(data.articles) : setError(data.message));
+    // .then(data => data.status === 'ok' ? setNews(data.articles.map((article, index) => ({...article, id: index}))) : setError(data.message));
   }, []);
+
+  const handleSearch = searchTerm => {
+    setSearched(true);
+    setSearchTerm(searchTerm);
+    searchNews(searchTerm)
+    .then(data => data.status === 'ok' ? setSearch(data.articles.map((article, index) => ({...article, id: index}))) : setError(data.message));
+  };
+
+  const resetSearch = () => {
+    setSearch([]);
+    setSearchTerm('');
+    setSearched(false);
+  };
 
   return (
     <Switch>
@@ -27,15 +42,22 @@ const App = () => {
         return (
           <main>
             <header>
-              <NavLink to='/' className='news'>News</NavLink>
-              <Search />
+              <h1 className='news' onClick={(resetSearch)}>News</h1>
+              <h2>{searched ? `Results for: "${searchTerm}"` : 'Top Stories'}</h2>
+              <Search handleSearch={handleSearch}/>
             </header>
-            <Articles articles={news}/>
+            <Articles articles={searched ? search : news}/>
           </main>
         );
       }}/>
       <Route exact path='/article/:id' render={({ match }) => {
-        const article = news.find(article => article.id === Number(match.params.id))
+        let article;
+
+        if (!searched) {
+          article = news.find(article => article.id === Number(match.params.id));
+        } else {
+          article = search.find(article => article.id === Number(match.params.id));
+        };
         
         return (
         <main>

--- a/src/components/ArticleCard/ArticleCard.css
+++ b/src/components/ArticleCard/ArticleCard.css
@@ -27,6 +27,8 @@
 
 .article-card > h3 {
   color: grey;
+  max-width: 95%;
+  overflow-wrap: break-word;
 }
 
 .article-card > p {

--- a/src/components/Articles/Articles.js
+++ b/src/components/Articles/Articles.js
@@ -7,7 +7,7 @@ const Articles = ({ articles }) => {
   
   return (
     <section className='articles'>
-      {articleCards}
+      {articles.length ? articles.map(article => <ArticleCard key={article.id} id={article.id} author={article.author} title={article.title} description={article.description} image={article.urlToImage} date={article.publishedAt} />) : <h1>No articles found</h1>}
     </section>
   );
 };

--- a/src/components/Search/Search.js
+++ b/src/components/Search/Search.js
@@ -1,10 +1,16 @@
 import './Search.css';
+import { useState } from 'react';
 
-const Search = () => {
+const Search = ({ handleSearch }) => {
+  const [search, setSearch] = useState('');
+  
   return (
     <div>
-      <input type='text' className='search'></input>
-      <button className='search'>Search</button>
+      <input type='text' className='search' value={search} onChange={(e) => setSearch(e.target.value)}></input>
+      <button className='search' onClick={() => {
+        handleSearch(search)
+        setSearch('');
+        }}>Search</button>
     </div>
   );
 };


### PR DESCRIPTION
- Added states for the search bar and resulting search terms
- Added an api call for searching for the keyword
- Added a failsafe message if there were no articles to load from search or initial homepage
- Left the search api call live even in dev since it's only running on a button click instead of every time the page loads
- Added a way to reset the page from the search results by clicking the title

closes #4 
closes #10 
closes #12 
